### PR TITLE
Additional config for compliance to the article

### DIFF
--- a/app-projects/infra.yml
+++ b/app-projects/infra.yml
@@ -10,6 +10,9 @@ spec:
   destinations:
   - name: '*'
     namespace: '*'
-    server: '*'  
+    server: '*'
+  clusterResourceWhitelist:
+  - group: ""
+    kind: Namespace
   sourceRepos:
   - https://github.com/kostis-codefresh/*


### PR DESCRIPTION
- Added user infra to the argo-cd cm
- Added a global role for infra user. The role is with high permissions and not project scoped. It can also be changed to project scoped and then appear on each existing team project along with each new ones.
- Added `clusterResourceWhitelist` with ns resource allowed to each project. At least at 2.13.0, auto-creation of a ns on an app does not work without this explicit config. 