### PR TITLE
Additional config for compliance to the article

### DIFF
--- a/app-projects/infra.yml
+++ b/app-projects/infra.yml
@@ -7,6 +7,9 @@ metadata:
     - resources-finalizer.argocd.argoproj.io  
 spec:
   description: Infrastructure resources
+  clusterResourceWhitelist:
+  - group: ""
+    kind: Namespace
   destinations:
   - name: '*'
     namespace: '*'

--- a/app-projects/team-a.yml
+++ b/app-projects/team-a.yml
@@ -11,6 +11,9 @@ spec:
   - name: '*'
     namespace: '*'
     server: '*'  
+clusterResourceWhitelist:
+  - group: ""
+    kind: Namespace
   roles:
   - description: Read Only
     name: read-only

--- a/app-projects/team-a.yml
+++ b/app-projects/team-a.yml
@@ -27,3 +27,4 @@ spec:
     - p, proj:team-a:read-write, applications, update, team-a/*, allow        
   sourceRepos:
   - https://github.com/kostis-codefresh/intro-argocd-rbac.git
+  

--- a/app-projects/team-a.yml
+++ b/app-projects/team-a.yml
@@ -11,7 +11,7 @@ spec:
   - name: '*'
     namespace: '*'
     server: '*'  
-clusterResourceWhitelist:
+  clusterResourceWhitelist:
   - group: ""
     kind: Namespace
   roles:

--- a/app-projects/team-b.yml
+++ b/app-projects/team-b.yml
@@ -11,6 +11,9 @@ spec:
   - name: '*'
     namespace: '*'
     server: '*'  
+  clusterResourceWhitelist:
+  - group: ""
+    kind: Namespace
   roles:
   - description: Read Only
     name: read-only

--- a/app-projects/team-b.yml
+++ b/app-projects/team-b.yml
@@ -27,3 +27,4 @@ spec:
     - p, proj:team-b:read-write, applications, update, team-b/*, allow        
   sourceRepos:
   - https://github.com/kostis-codefresh/intro-argocd-rbac.git
+  

--- a/local-users/argocd-rbac-cm.yml
+++ b/local-users/argocd-rbac-cm.yml
@@ -10,6 +10,8 @@ data:
   policy.csv: |
     g, jane, proj:team-a:read-write
     g, jane, proj:team-b:read-only
-    g, david, proj:team-b:read-write        
+    g, david, proj:team-b:read-write
+    p, infra, applications, *, */*, allow
+    p, infra, projects, get, *, allow       
 
 

--- a/local-users/simple-scenario.yml
+++ b/local-users/simple-scenario.yml
@@ -10,4 +10,6 @@ data:
   accounts.jane: apiKey, login
   accounts.jane.enabled: "true"
   accounts.david: apiKey, login
-  accounts.david.enabled: "true"  
+  accounts.david.enabled: "true" 
+  accounts.infra: apiKey,login
+  accounts.infra.enabled: "true"

--- a/local-users/simple-scenario.yml
+++ b/local-users/simple-scenario.yml
@@ -10,6 +10,7 @@ data:
   accounts.jane: apiKey, login
   accounts.jane.enabled: "true"
   accounts.david: apiKey, login
-  accounts.david.enabled: "true" 
+  accounts.david.enabled: "true"
   accounts.infra: apiKey,login
   accounts.infra.enabled: "true"
+  


### PR DESCRIPTION
- Added user infra to the argo-cd cm
- Added a global role for infra user. The role is with high permissions and not project scoped. It can also be changed to project scoped and then appear on each existing team project along with each new ones.
- Added `clusterResourceWhitelist` with ns resource allowed to each project. At least at 2.13.0, auto-creation of a ns on an app does not work without this explicit config. 